### PR TITLE
Add meta for Naver webmastertool #24

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,7 @@ module.exports = {
     title: `SAT10AM`,
     description: `A Study Blog for SAT10AM`,
     author: `@y0c`,
+    naverSiteVerification: 'b1076669177dae5b58f7fc5563e631a428968f5f',
   },
   plugins: [
     `gatsby-plugin-react-helmet`,

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -19,6 +19,7 @@ function SEO({ description, lang, meta, keywords, title }) {
             title
             description
             author
+            naverSiteVerification
           }
         }
       }
@@ -26,6 +27,7 @@ function SEO({ description, lang, meta, keywords, title }) {
   )
 
   const metaDescription = description || site.siteMetadata.description
+  const { naverSiteVerification } = site.siteMetadata;
 
   return (
     <Helmet
@@ -67,13 +69,17 @@ function SEO({ description, lang, meta, keywords, title }) {
           name: `twitter:description`,
           content: metaDescription,
         },
+        {
+          name: `naver-site-verification`,
+          content: naverSiteVerification,
+        },
       ]
         .concat(
           keywords.length > 0
             ? {
-                name: `keywords`,
-                content: keywords.join(`, `),
-              }
+              name: `keywords`,
+              content: keywords.join(`, `),
+            }
             : []
         )
         .concat(meta)}


### PR DESCRIPTION
#24 네이버 웹마스터 도구에 사이트 등록을 위한 meta tag 추가가 필요합니다
`gatsby-config.js` 와 `seo.jsx` 파일에서 메타를 추가하여 작업 했습니다